### PR TITLE
fix verbose mode in brotli.c

### DIFF
--- a/c/tools/brotli.c
+++ b/c/tools/brotli.c
@@ -176,7 +176,7 @@ static Command ParseAlias(const char* name) {
   /* Partial comparison. On Windows there could be ".exe" suffix. */
   if (strncmp(name, unbrotli, unbrotli_len) == 0) {
     char terminator = name[unbrotli_len];
-    if (terminator == 0 || terminator == '.') return COMMAND_DECOMPRESS;
+    if (terminator == 0 || terminator == '.') return COMMAND_HELP;
   }
   return COMMAND_COMPRESS;
 }


### PR DESCRIPTION
when use brotli -v,it will show verbose and compress/decompress files. This change will make it showing how to use brotli correctly instead of decompressing files. 